### PR TITLE
Update version and add gamerule for speed multiplier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,7 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	// modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,10 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.10
+minecraft_version=1.21.5
+yarn_mappings=1.21.5+build.1
 loader_version=0.15.10
+fabric_version=0.119.5+1.21.5
 
 # Mod Properties
 mod_version=1.0.2

--- a/src/main/java/b100/fastminecart/FastMinecartMod.java
+++ b/src/main/java/b100/fastminecart/FastMinecartMod.java
@@ -1,0 +1,18 @@
+package b100.fastminecart;
+
+import net.minecraft.world.GameRules;
+import net.minecraft.world.GameRules.Category;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.gamerule.v1.GameRuleFactory;
+import net.fabricmc.fabric.api.gamerule.v1.GameRuleRegistry;
+
+public class FastMinecartMod implements ModInitializer {
+
+    public static GameRules.Key<GameRules.IntRule> MINECART_SPEED_MULTIPLIER;
+
+    @Override
+    public void onInitialize() {
+        MINECART_SPEED_MULTIPLIER = GameRuleRegistry
+                .register("minecartSpeedMultiplier", Category.MISC, GameRuleFactory.createIntRule(2));
+    }
+}

--- a/src/main/java/b100/fastminecart/mixin/MinecartMixin.java
+++ b/src/main/java/b100/fastminecart/mixin/MinecartMixin.java
@@ -5,27 +5,38 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import b100.fastminecart.FastMinecartMod;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.vehicle.AbstractMinecartEntity;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.World;
 
 @Mixin(value = AbstractMinecartEntity.class)
 public abstract class MinecartMixin extends Entity {
-	
+
 	public MinecartMixin(EntityType<?> type, World world) {
 		super(type, world);
 	}
 
 	private boolean isRepeat = false;
-	
+
 	@Inject(method = "tick", at = @At("HEAD"))
 	public void tickInject(CallbackInfo ci) {
-		if(!isRepeat) {
+		if (!isRepeat) {
 			isRepeat = true;
-			tick();
+			World world = this.getWorld();
+			if (world != null) {
+				MinecraftServer server = world.getServer();
+				if (server != null) {
+					int multiplier = server.getGameRules().getInt(FastMinecartMod.MINECART_SPEED_MULTIPLIER);
+					for (int i = 1; i < multiplier; i++) {
+						tick();
+					}
+				}
+			}
 			isRepeat = false;
-		}	
+		}
 	}
 
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -10,6 +10,11 @@
 	"license": "CC0-1.0",
 	"icon": "assets/fastminecart/icon.png",
 	"environment": "*",
+	"entrypoints": {
+		"main": [
+			"b100.fastminecart.FastMinecartMod"
+		]
+	},
 	"mixins": [
 		"fastminecart.mixins.json"
 	],


### PR DESCRIPTION
It needs a version bump, but I updated the mod for minecraft 1.21.5 and I created a gamerule you can use to modify the minecart's speed multiplier.